### PR TITLE
Fix weird indentation

### DIFF
--- a/src/main/resources/chime.mixins.json
+++ b/src/main/resources/chime.mixins.json
@@ -4,8 +4,8 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [],
   "client": [
-	"ModelOverrideMixin",
-	"ModelOverrideDeserializerMixin",
+    "ModelOverrideMixin",
+    "ModelOverrideDeserializerMixin",
     "ArmorFeatureRendererMixin",
     "JsonUnbakedModelMixin",
     "BakedModelOverrideMixin",

--- a/src/main/resources/chime.mixins.json
+++ b/src/main/resources/chime.mixins.json
@@ -4,8 +4,8 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [],
   "client": [
-	  "ModelOverrideMixin",
-	  "ModelOverrideDeserializerMixin",
+	"ModelOverrideMixin",
+	"ModelOverrideDeserializerMixin",
     "ArmorFeatureRendererMixin",
     "JsonUnbakedModelMixin",
     "BakedModelOverrideMixin",


### PR DESCRIPTION
Hi! This is an awesome project, and I find it very helpful for Minecraft maps.

This PR fixes some weird indentations in chime.mixins.json.

Thanks for a handy tool, and I can't wait to see how it expands in the future. :)