### PR TITLE
Fix Jitpack support

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,10 @@
 jdk:
   - openjdk17
+before_install:
+  - echo "Before Install"
+  - bash ensure-java-17 install
+install:
+  - echo "Install"
+  - if ! bash ensure-java-17 use; then source ~/.sdkman/bin/sdkman-init.sh; fi
+  - java -version
+  - mvn install

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 before_install:
   - export SDKMAN_DIR="/home/jitpack/sdkman" && curl -s "https://get.sdkman.io" | bash
   - source "/home/jitpack/sdkman/bin/sdkman-init.sh"
-  - sdk install java 17.34.19-zulu
-  - sdk use java 17.34.19-zulu
+  - sdk install java 17.0.3-zulu
+  - sdk use java 17.0.3-zulu

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 before_install:
   - export SDKMAN_DIR="/home/jitpack/sdkman" && curl -s "https://get.sdkman.io" | bash
   - source "/home/jitpack/sdkman/bin/sdkman-init.sh"
-  - sdk install java 18.0.1+10-zulu
-  - sdk use java 18.0.1+10-zulu
+  - sdk install java 17.34.19-zulu
+  - sdk use java 17.34.19-zulu

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,5 @@
 before_install:
- - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
- - source ./install-jdk.sh --feature 17 --license GPL
+  - export SDKMAN_DIR="/home/jitpack/sdkman" && curl -s "https://get.sdkman.io" | bash
+  - source "/home/jitpack/sdkman/bin/sdkman-init.sh"
+  - sdk install java 18.0.1+10-zulu
+  - sdk use java 18.0.1+10-zulu

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,10 +1,3 @@
-jdk:
-  - openjdk17
 before_install:
-  - echo "Before Install"
-  - bash ensure-java-17 install
-install:
-  - echo "Install"
-  - if ! bash ensure-java-17 use; then source ~/.sdkman/bin/sdkman-init.sh; fi
-  - java -version
-  - mvn install
+ - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+ - source ./install-jdk.sh --feature 17 --license GPL


### PR DESCRIPTION
Does what it says on the tin, basically: by adding `jitpack.yml`, jitpack is properly able to provide chime as a dependency to gradle projects after it was broken due to java 17 not being jitpack's default java version.

The final 1.18 build of Chime also has a fixed version in a separate branch on the fork I am making this PR from.